### PR TITLE
Wrapped I/O streams and several code optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set (STATIC_DIR "" CACHE STRING "Build in 'static' mode and include libraries in
 ############
 set (popvcf_VERSION_MAJOR 1)
 set (popvcf_VERSION_MINOR 0)
-set (popvcf_VERSION_PATCH 0)
+set (popvcf_VERSION_PATCH 1)
 
 add_subdirectory(src) # Exposes "popvcf_sources", which contains all source files of popvcf
 add_library(popvcf_objects OBJECT ${popvcf_sources})

--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 ## popVCF
 
-popVCF losslessly encodes a multi sample VCF to reduce disk footprint. VCF fields are encoded by pointing to other exactly identical fields in the same row or in the row above. popVCF performance is small on a single sample VCF, but the compression ratio can go up to 40+ on a large population VCF or 5x more compressed than the standard bgzip compression.
+popVCF losslessly encodes a multi sample VCF to reduce disk footprint. VCF fields are encoded by pointing to other exactly identical fields in the same row or in the row above. popVCF compression performance is small on a single sample VCF, but the compression ratio can go up to 40+ on a large population VCF or 5x more compressed than the standard bgzip compression.
 
-### Building
-Feature complete C++17 compiler is required for building popVCF, i.e. GCC 8/Clang 10 or newer.
+Files are encoded with the "popvcf encode" command, and by encoding with the "-Oz" flag you can directly write the output in bgzip format. You can then decode the file back to VCF using the "popvcf decode" command. The decode subcommand can also query a region using option "--region=chrN:A-B".
 
-```sh
-git clone --recursive <url> popvcf # Clone the repository
-cd popvcf
-mkdir build-release
-cd build-release
-cmake ..
-make -j3 popvcf
-```
+On a 64 bit linux, you can get the latest static binary from the [Release page](https://github.com/DecodeGenetics/popvcf/releases).
 
 ### Usage
 
@@ -26,6 +18,18 @@ popvcf encode my.vcf -Oz > my.popvcf.gz
 tabix my.popvcf.gz
 popvcf decode my.popvcf.gz > my.new2.vcf
 popvcf decode my.popvcf.gz --region=chrN:A-B > my.region.vcf # Random access a region using the tabix index
+```
+
+### Building
+Feature complete C++17 compiler is required for building popVCF, i.e. GCC 8/Clang 10 or newer.
+
+```sh
+git clone --recursive <url> popvcf # Clone the repository
+cd popvcf
+mkdir build-release
+cd build-release
+cmake ..
+make -j3 popvcf
 ```
 
 ### License

--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -32,9 +32,9 @@ run ()
 
 
 echo "== Compression times =="
-run "bgzip -c -f test.vcf ${level} > test.vcf.gz"
-run "${popvcf} encode test.vcf > test.vcf.popvcf"
-run "${popvcf} encode test.vcf ${level} -Oz > test.vcf.popvcf.gz"
+run "bgzip --stdout --force --threads 1 test.vcf ${level} > test.vcf.gz"
+run "${popvcf} encode test.vcf -o test.vcf.popvcf"
+run "${popvcf} encode test.vcf ${level} -Oz -o test.vcf.popvcf.gz"
 run "spvcf encode --quiet --no-squeeze test.vcf > test.vcf.spvcf"
 run "spvcf encode --quiet --no-squeeze test.vcf | bgzip -c ${level} > test.vcf.spvcf.gz"
 
@@ -46,7 +46,7 @@ run "${popvcf} decode test.vcf.popvcf.gz > test.vcf.popvcf.gz.vcf"
 md5sum test.vcf.popvcf.gz.vcf ; rm -f test.vcf.popvcf.gz.vcf
 run "bgzip -dc test.vcf.spvcf.gz | spvcf decode --quiet > test.vcf.spvcf.gz.vcf"
 md5sum test.vcf.spvcf.gz.vcf ; rm -f test.vcf.spvcf.gz.vcf
-run "bgzip -c -d -k -f test.vcf.gz > test.vcf.gz.vcf"
+run "bgzip -dc test.vcf.gz > test.vcf.gz.vcf"
 md5sum test.vcf.gz.vcf ; rm -f test.vcf.gz.vcf
 
 echo "== Index construction times =="
@@ -67,4 +67,4 @@ original_size=$(find -L . -name "test.vcf" -printf "%s\n")
 find . -name "test.*gz" -printf "%f\t%s\n" | awk -v os="${original_size}" '{print $1"\t"$2"\t"os/$2}'
 
 # cleanup
-echo test.* | tr ' ' '\n' | grep -vP "^test.vcf$" | grep -vP "^test.vcf.gz$" | xargs rm
+#echo test.* | tr ' ' '\n' | grep -vP "^test.vcf$" | grep -vP "^test.vcf.gz$" | xargs rm

--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -46,23 +46,19 @@ run "${popvcf} decode test.vcf.popvcf.gz > test.vcf.popvcf.gz.vcf"
 md5sum test.vcf.popvcf.gz.vcf ; rm -f test.vcf.popvcf.gz.vcf
 run "bgzip -dc test.vcf.spvcf.gz | spvcf decode --quiet > test.vcf.spvcf.gz.vcf"
 md5sum test.vcf.spvcf.gz.vcf ; rm -f test.vcf.spvcf.gz.vcf
-#run "${popvcf} decode test.vcf.popvcf.l9.gz > test.vcf.popvcf.l9.gz.vcf"
-#md5sum test.vcf.popvcf.l9.gz.vcf ; rm -f test.vcf.popvcf.l9.gz.vcf
-
 run "bgzip -c -d -k -f test.vcf.gz > test.vcf.gz.vcf"
 md5sum test.vcf.gz.vcf ; rm -f test.vcf.gz.vcf
-
 
 echo "== Index construction times =="
 run "tabix -p vcf -f test.vcf.gz"
 run "tabix -p vcf -f test.vcf.popvcf.gz"
 run "tabix -p vcf -f test.vcf.spvcf.gz"
-#run "tabix -f test.vcf.popvcf.l9.gz"
 
-#echo "== Query times =="
-#run "tabix test.vcf.gz chr20:17625500-17625600 > /dev/null"
-#run "tabix test.vcf.popvcf.gz chr20:17625500-17625600 | ${popvcf} decode - > /dev/null"
-#run "tabix test.vcf.popvcf.l9.gz chr20:17625500-17625600 | ${popvcf} decode - > /dev/null"
+echo "== Query times =="
+region=$(grep -v ^# test.vcf | cut -f1,2 | head -n 20 | tail -n 1 | awk '{print $1":"$2"-"$2+100}')
+run "tabix test.vcf.gz ${region} > /dev/null"
+run "${popvcf} decode test.vcf.popvcf.gz --region=${region} > /dev/null"
+run "spvcf tabix test.vcf.spvcf.gz ${region} | spvcf decode - > /dev/null"
 
 ls -lh test.*gz
 ls -l test.*gz

--- a/src/decode.hpp
+++ b/src/decode.hpp
@@ -27,7 +27,6 @@ class DecodeData
 {
 public:
   std::size_t bytes_read{0};
-  std::size_t remaining_bytes{0};
   std::size_t field{0};   // current vcf field
   std::size_t b{0};       // begin index in buffer_in
   std::size_t i{b};       // index in buffer_in
@@ -71,7 +70,7 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
   std::size_t constexpr N_FIELDS_SITE_DATA{9};
 
   // inner loop - Loops over each character in the input buffer
-  while (dd.i < (dd.bytes_read + dd.remaining_bytes))
+  while (dd.i < dd.bytes_read)
   {
     char const b_in = buffer_in[dd.i];
 
@@ -196,10 +195,10 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
   } // ends inner loop
 
   // write data to the beginning of the input buffer
-  dd.remaining_bytes = dd.i - dd.b;
-  std::copy(&buffer_in[dd.b], &buffer_in[dd.b + dd.remaining_bytes], &buffer_in[0]);
+  std::copy(&buffer_in[dd.b], &buffer_in[dd.i], &buffer_in[0]);
+  dd.i = dd.i - dd.b;
   dd.b = 0;
-  dd.i = dd.remaining_bytes;
+  dd.bytes_read = dd.i;
 }
 
 //! Decode an encoded popVCF

--- a/src/decode.hpp
+++ b/src/decode.hpp
@@ -17,22 +17,15 @@
 
 namespace popvcf
 {
-//! Buffer size when decoding
-long constexpr DEC_BUFFER_SIZE{8 * 65536};
-
-//! Data type of an array buffer
-using Tdec_array_buf = std::array<char, DEC_BUFFER_SIZE>;
-
 class DecodeData
 {
 public:
-  std::size_t bytes_read{0};
-  std::size_t field{0};   // current vcf field
-  std::size_t b{0};       // begin index in buffer_in
-  std::size_t i{b};       // index in buffer_in
-  std::size_t o{0};       // output index
+  std::size_t field{0};   //!< Current vcf field
+  std::size_t in_size{0}; //!< Size of input buffer.
+  std::size_t b{0};       //!< Field begin index in input buffer.
+  std::size_t i{b};       //!< Curent index in input buffer
   bool header_line{true}; //!< True iff in header line
-  bool in_region{true};
+  bool in_region{true};   //!< True iff in region
 
   int64_t pos{-1};
   int64_t begin{-1};
@@ -57,20 +50,34 @@ public:
     map_to_unique_fields.clear();
   }
 
-  inline uint32_t num_unique_fields()
+  inline uint32_t num_unique_fields() const
   {
     return unique_fields.size();
   }
 };
 
+template <typename Tbuffer_in>
+inline void set_input_size(Tbuffer_in & buffer_in, DecodeData & dd)
+{
+  dd.in_size = buffer_in.size();
+}
+
+template <>
+inline void set_input_size(Tdec_array_buf & /*buffer_in*/, DecodeData & /*dd*/)
+{
+  // Do nothing.
+  // NOTE: dd.in_size must be set prior to calling decode_buffer in arrays
+}
+
 //! Decodes an input buffer. Output is written in \a buffer_out .
-template <typename Tbuffer_out, typename Tbuffer_in>
+template <bool is_region, typename Tbuffer_out, typename Tbuffer_in>
 inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, DecodeData & dd)
 {
+  set_input_size(buffer_in, dd);
   std::size_t constexpr N_FIELDS_SITE_DATA{9};
 
   // inner loop - Loops over each character in the input buffer
-  while (dd.i < dd.bytes_read)
+  while (dd.i < dd.in_size)
   {
     char const b_in = buffer_in[dd.i];
 
@@ -87,7 +94,11 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
     else if (dd.header_line == false && dd.field == 1)
     {
       std::from_chars(&buffer_in[dd.b], &buffer_in[dd.i], dd.pos); // get pos
-      dd.in_region = dd.pos >= dd.begin && dd.pos <= dd.end;
+
+      if constexpr (is_region)
+      {
+        dd.in_region = dd.pos >= dd.begin && dd.pos <= dd.end;
+      }
     }
 
     if (dd.header_line || dd.field < N_FIELDS_SITE_DATA)
@@ -95,8 +106,8 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
       // write field without any encoding
       ++dd.i; // adds '\t' or '\n'
 
-      if (dd.in_region)
-        std::copy(&buffer_in[dd.b], &buffer_in[dd.i], std::back_inserter(buffer_out));
+      if (!is_region || dd.in_region)
+        buffer_out.insert(buffer_out.end(), &buffer_in[dd.b], &buffer_in[dd.i]);
     }
     else
     {
@@ -127,9 +138,9 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
 
         ++dd.i;
 
-        if (dd.in_region)
+        if (!is_region || dd.in_region)
         {
-          std::copy(prior_field.begin(), prior_field.end(), std::back_inserter(buffer_out));
+          buffer_out.insert(buffer_out.end(), prior_field.begin(), prior_field.end());
           buffer_out.push_back(b_in);
         }
       }
@@ -142,12 +153,12 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
         std::string const & prior_field = dd.prev_unique_fields[prev_unique_index];
 
         dd.map_to_unique_fields.insert(std::pair<std::string, uint32_t>(prior_field, dd.num_unique_fields()));
-        dd.field2uid.push_back(dd.unique_fields.size());
+        dd.field2uid.push_back(dd.num_unique_fields());
         dd.unique_fields.push_back(prior_field);
 
-        if (dd.in_region)
+        if (!is_region || dd.in_region)
         {
-          std::copy(prior_field.begin(), prior_field.end(), std::back_inserter(buffer_out));
+          buffer_out.insert(buffer_out.end(), prior_field.begin(), prior_field.end());
           buffer_out.push_back(b_in);
         }
       }
@@ -159,9 +170,9 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
         dd.field2uid.push_back(unique_index);
         std::string const & prior_field = dd.unique_fields[unique_index];
 
-        if (dd.in_region)
+        if (!is_region || dd.in_region)
         {
-          std::copy(prior_field.begin(), prior_field.end(), std::back_inserter(buffer_out));
+          buffer_out.insert(buffer_out.end(), prior_field.begin(), prior_field.end());
           buffer_out.push_back(b_in);
         }
       }
@@ -178,8 +189,8 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
         dd.unique_fields.push_back(insert_it.first->first);
         ++dd.i;
 
-        if (dd.in_region)
-          std::copy(&buffer_in[dd.b], &buffer_in[dd.i], std::back_inserter(buffer_out));
+        if (!is_region || dd.in_region)
+          buffer_out.insert(buffer_out.end(), &buffer_in[dd.b], &buffer_in[dd.i]);
       }
 
       assert((field_idx + 1) == static_cast<long>(dd.field2uid.size()));
@@ -198,7 +209,8 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
   std::copy(&buffer_in[dd.b], &buffer_in[dd.i], &buffer_in[0]);
   dd.i = dd.i - dd.b;
   dd.b = 0;
-  dd.bytes_read = dd.i;
+  dd.in_size = dd.i;
+  resize_input_buffer(buffer_in, dd.i);
 }
 
 //! Decode an encoded popVCF

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -31,8 +31,8 @@ void encode_file(std::string const & input_fn,
   ed.no_previous_line = no_previous_line;
 
   /// Open input file streams
-  BGZF * in_bgzf{nullptr}; // bgzf input stream
-  FILE * in_vcf{nullptr};  // vcf input stream
+  popvcf::bgzf_ptr in_bgzf(nullptr, popvcf::close_bgzf);   // bgzf input stream
+  popvcf::file_ptr in_vcf(nullptr, popvcf::close_vcf_nop); // vcf input stream
 
   if (is_bgzf_input)
     in_bgzf = popvcf::open_bgzf(input_fn, "r");
@@ -40,15 +40,15 @@ void encode_file(std::string const & input_fn,
     in_vcf = popvcf::open_vcf(input_fn, "r");
 
   /// Open output file streams
-  BGZF * out_bgzf{nullptr}; // bgzf output stream
-  FILE * out_vcf{nullptr};  // vcf output stream
+  popvcf::bgzf_ptr out_bgzf(nullptr, popvcf::close_bgzf);   // bgzf output stream
+  popvcf::file_ptr out_vcf(nullptr, popvcf::close_vcf_nop); // vcf output stream
 
   if (is_bgzf_output)
   {
     out_bgzf = popvcf::open_bgzf(output_fn.c_str(), output_mode.c_str());
 
     if (compression_threads > 1)
-      bgzf_mt(out_bgzf, compression_threads, 256);
+      bgzf_mt(out_bgzf.get(), compression_threads, 256);
   }
   else
   {
@@ -57,62 +57,46 @@ void encode_file(std::string const & input_fn,
 
   /// Read first buffer of input data
   if (is_bgzf_input)
-    ed.bytes_read = bgzf_read(in_bgzf, buffer_in.data(), ENC_BUFFER_SIZE);
+    ed.bytes_read = bgzf_read(in_bgzf.get(), buffer_in.data(), ENC_BUFFER_SIZE);
   else
-    ed.bytes_read = fread(buffer_in.data(), 1, ENC_BUFFER_SIZE, in_vcf);
+    ed.bytes_read = fread(buffer_in.data(), 1, ENC_BUFFER_SIZE, in_vcf.get());
+
+  long new_bytes = ed.bytes_read;
 
   // loop until all data has been read
-  while (ed.bytes_read != 0)
+  while (new_bytes != 0)
   {
     // encode the input buffer and write to output buffer
     encode_buffer(buffer_out, buffer_in, ed);
 
     // write output buffer
     if (out_bgzf != nullptr)
-    {
-      long const written_bytes = bgzf_write(out_bgzf, buffer_out.data(), buffer_out.size());
-
-      if (written_bytes != static_cast<long>(buffer_out.size()))
-      {
-        std::cerr << "[popvcf] WARNING: Problem writing bgzf data to " << output_fn << " " << written_bytes
-                  << " bytes written but expected " << buffer_out.size() << " bytes." << std::endl;
-      }
-    }
+      popvcf::write_bgzf(out_bgzf.get(), buffer_out.data(), buffer_out.size());
     else
-    {
-      fwrite(buffer_out.data(), 1, buffer_out.size(), out_vcf); // write output buffer
-    }
+      fwrite(buffer_out.data(), 1, buffer_out.size(), out_vcf.get()); // write output buffer
 
     buffer_out.resize(0);
+    new_bytes = -static_cast<long>(ed.bytes_read);
 
     // attempt to read more data from input
     if (is_bgzf_input)
-      ed.bytes_read += bgzf_read(in_bgzf, buffer_in.data() + ed.bytes_read, ENC_BUFFER_SIZE - ed.bytes_read);
+      ed.bytes_read += bgzf_read(in_bgzf.get(), buffer_in.data() + ed.bytes_read, ENC_BUFFER_SIZE - ed.bytes_read);
     else
-      ed.bytes_read += fread(buffer_in.data() + ed.bytes_read, 1, ENC_BUFFER_SIZE - ed.bytes_read, in_vcf);
+      ed.bytes_read += fread(buffer_in.data() + ed.bytes_read, 1, ENC_BUFFER_SIZE - ed.bytes_read, in_vcf.get());
+
+    new_bytes += ed.bytes_read;
   }
 
-  /// Close input streams
-  if (in_bgzf != nullptr)
-    popvcf::close_bgzf(in_bgzf);
-  else if (output_fn != "-")
-    fclose(in_vcf);
+  if (ed.bytes_read != 0)
+  {
+    std::cerr << "[popvcf] WARNING: Unexpected ending of the VCF data, possibly the file is truncated.\n";
 
-  /// Close output streams
-  if (out_bgzf != nullptr)
-    popvcf::close_bgzf(out_bgzf);
-  else if (output_fn != "-")
-    fclose(out_vcf);
+    // write output buffer
+    if (out_bgzf != nullptr)
+      popvcf::write_bgzf(out_bgzf.get(), buffer_in.data(), ed.bytes_read);
+    else
+      fwrite(buffer_in.data(), 1, ed.bytes_read, out_vcf.get()); // write output buffer
+  }
 }
-
-/*
-template void encode_buffer(std::string & buffer_out, Tarray_buf & buffer_in, EncodeData & ed);
-template void encode_buffer(std::vector<char> & buffer_out, Tarray_buf & buffer_in, EncodeData & ed);
-template void encode_buffer(Tarray_buf & buffer_out, Tarray_buf & buffer_in, EncodeData & ed);
-template void encode_buffer(std::string & buffer_out, std::string & buffer_in, EncodeData & ed);
-template void encode_buffer(std::vector<char> & buffer_out, std::string & buffer_in, EncodeData & ed);
-template void encode_buffer(std::string & buffer_out, std::vector<char> & buffer_in, EncodeData & ed);
-template void encode_buffer(std::vector<char> & buffer_out, std::vector<char> & buffer_in, EncodeData & ed);
-*/
 
 } // namespace popvcf

--- a/src/encode.hpp
+++ b/src/encode.hpp
@@ -212,12 +212,6 @@ inline void encode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Enco
       ++ed.field;
   } // ends inner loop
 
-  if (ed.b == 0)
-  {
-    throw std::runtime_error("ERROR: Encountered a field or line exceeding maximum buffer size of " +
-                             std::to_string(ENC_BUFFER_SIZE));
-  }
-
   // copy the remaining data to the beginning of the input buffer
   std::copy(&buffer_in[ed.b], &buffer_in[ed.i], &buffer_in[0]);
   ed.i = ed.i - ed.b;

--- a/src/encode.hpp
+++ b/src/encode.hpp
@@ -12,21 +12,15 @@
 
 namespace popvcf
 {
-//! Buffer size when encoding
-long constexpr ENC_BUFFER_SIZE{4 * 65536};
-
-//! Data type of an array buffer
-using Tarray_buf = std::array<char, ENC_BUFFER_SIZE>; //!< Buffer type
-
 class EncodeData
 {
 public:
-  std::size_t bytes_read{0};
-  std::size_t field{0};         // current vcf field
-  std::size_t b{0};             // begin index in buffer_in
-  std::size_t i{b};             // index in buffer_in
+  std::size_t field{0};         //!< current vcf field.
+  std::size_t in_size{0};       //!< Size of inut buffer.
+  std::size_t b{0};             //!< begin index in buffer_in
+  std::size_t i{b};             //!< index in buffer_in
   bool header_line{true};       //!< True iff in header line
-  bool no_previous_line{false}; //! Set to skip using previous line
+  bool no_previous_line{false}; //!< Set to skip using previous line
 
   std::string prev_contig{};
   int64_t prev_pos{0};
@@ -65,28 +59,28 @@ public:
   }
 };
 
-template <typename Tint, typename Tbuffer_out>
-inline void to_chars(Tint char_val, Tbuffer_out & buffer_out)
+template <typename Tbuffer_in>
+inline void set_input_size(Tbuffer_in & buffer_in, EncodeData & ed)
 {
-  while (char_val >= CHAR_SET_SIZE)
-  {
-    auto rem = char_val % CHAR_SET_SIZE;
-    char_val = char_val / CHAR_SET_SIZE;
-    buffer_out.push_back(int_to_ascii(rem));
-  }
+  ed.in_size = buffer_in.size();
+}
 
-  assert(char_val < CHAR_SET_SIZE);
-  buffer_out.push_back(int_to_ascii(char_val));
+template <>
+inline void set_input_size(Tenc_array_buf & /*buffer_in*/, EncodeData & /*dd*/)
+{
+  // Do nothing.
+  // NOTE: dd.in_size must be set prior to calling decode_buffer in arrays
 }
 
 //! Encodes an input buffer. Output is written in \a buffer_out.
 template <typename Tbuffer_out, typename Tbuffer_in>
 inline void encode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, EncodeData & ed)
 {
-  buffer_out.reserve(ENC_BUFFER_SIZE / 2);
+  set_input_size(buffer_in, ed);
+  buffer_out.reserve(ENC_BUFFER_SIZE);
   std::size_t constexpr N_FIELDS_SITE_DATA{9}; // how many fields of the VCF contains site data
 
-  while (ed.i < ed.bytes_read)
+  while (ed.i < ed.in_size)
   {
     char const b_in = buffer_in[ed.i];
 
@@ -123,8 +117,8 @@ inline void encode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Enco
 
     if (ed.header_line || ed.field < N_FIELDS_SITE_DATA)
     {
-      ++ed.i; // adds '\t' or '\n'
-      std::copy(&buffer_in[ed.b], &buffer_in[ed.i], std::back_inserter(buffer_out));
+      ++ed.i; // adds '\t' or '\n' and then insert the field to the output buffer
+      buffer_out.insert(buffer_out.end(), &buffer_in[ed.b], &buffer_in[ed.i]);
     }
     else
     {
@@ -164,8 +158,8 @@ inline void encode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Enco
           if (prev_find_it == ed.prev_map_to_unique_fields.end())
           {
             /* Case 1: Field is unique in the current line and is not in the previous line. */
-            ++ed.i;                                                                        // adds '\t' or '\n'
-            std::copy(&buffer_in[ed.b], &buffer_in[ed.i], std::back_inserter(buffer_out)); // just copy as is
+            ++ed.i; // adds '\t' or '\n'
+            buffer_out.insert(buffer_out.end(), &buffer_in[ed.b], &buffer_in[ed.i]);
           }
           else
           {
@@ -216,7 +210,8 @@ inline void encode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Enco
   std::copy(&buffer_in[ed.b], &buffer_in[ed.i], &buffer_in[0]);
   ed.i = ed.i - ed.b;
   ed.b = 0;
-  ed.bytes_read = ed.i;
+  ed.in_size = ed.i;
+  resize_input_buffer(buffer_in, ed.i);
 }
 
 //! Encode a gzipped file and write to stdout

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -2,38 +2,50 @@
 
 #include <cstdio>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "htslib/bgzf.h"
+#include "htslib/hts.h"
+#include "htslib/kseq.h"
+#include "htslib/tbx.h"
 
 class BGZF;
 
 namespace popvcf
 {
-static inline BGZF * open_bgzf(std::string const & fn, std::string const & filemode)
+using file_ptr = std::unique_ptr<FILE, void (*)(FILE *)>;           //!< Type definition for a smart FILE pointer.
+using bgzf_ptr = std::unique_ptr<BGZF, void (*)(BGZF *)>;           //!< Type definition for a smart BGZF pointer.
+using hts_file_ptr = std::unique_ptr<htsFile, void (*)(htsFile *)>; //!< Type definition for a smart htsFile pointer.
+using tbx_t_ptr = std::unique_ptr<tbx_t, void (*)(tbx_t *)>;        //!< Type definition for a smart tbx_t pointer.
+using hts_itr_t_ptr = std::unique_ptr<hts_itr_t, void (*)(hts_itr_t *)>; //!< Type definition for a hts_itr_t pointer.
+
+//! Closes a VCF file stream, i.e. stdout/stdin
+inline void close_vcf_nop(FILE *)
 {
-  BGZF * in_bgzf = bgzf_open(fn.c_str(), filemode.c_str());
-
-  if (in_bgzf == nullptr)
-  {
-    std::cerr << "[popvcf] ERROR: Opening bgzf file " << fn << std::endl;
-    std::exit(1);
-  }
-
-  return in_bgzf;
 }
 
-static inline FILE * open_vcf(std::string const & fn, std::string const & filemode)
+//! Closes VCF file
+inline void close_vcf(FILE * f)
+{
+  if (f != nullptr)
+  {
+    fclose(f);
+  }
+}
+
+//! Opens a VCF file either from filename or stdout/stdin
+inline file_ptr open_vcf(std::string const & fn, std::string const & filemode)
 {
   if (fn == "-")
   {
     if (filemode == "r")
-      return stdin;
+      return file_ptr(stdin, popvcf::close_vcf_nop);
     else
-      return stdout;
+      return file_ptr(stdout, popvcf::close_vcf_nop);
   }
 
-  FILE * in_vcf = fopen(fn.c_str(), filemode.c_str());
+  file_ptr in_vcf(fopen(fn.c_str(), filemode.c_str()), popvcf::close_vcf);
 
   if (in_vcf == nullptr)
   {
@@ -44,14 +56,107 @@ static inline FILE * open_vcf(std::string const & fn, std::string const & filemo
   return in_vcf;
 }
 
-static inline void close_bgzf(BGZF * bgzf)
+inline void write_bgzf(BGZF * bgzf, const char * data, std::size_t const size)
 {
-  int ret = bgzf_close(bgzf);
+  assert(bgzf != nullptr);
+  std::size_t const written_bytes = bgzf_write(bgzf, data, size);
 
-  if (ret != 0)
+  if (written_bytes != size)
   {
-    std::cerr << "[popvcf] ERROR: Failed closing bgzf file." << std::endl;
+    std::cerr << "[popvcf] WARNING: Problem writing bgzf data. " << written_bytes << " bytes written but expected "
+              << size << " bytes.\n";
     std::exit(1);
   }
+}
+
+inline void close_bgzf(BGZF * bgzf)
+{
+  if (bgzf != nullptr)
+  {
+    if (bgzf_close(bgzf) != 0)
+    {
+      std::cerr << "[popvcf] ERROR: Failed closing bgzf file." << std::endl;
+      std::exit(1);
+    }
+  }
+}
+
+inline bgzf_ptr open_bgzf(std::string const & fn, std::string const & filemode)
+{
+  bgzf_ptr in_bgzf(bgzf_open(fn.c_str(), filemode.c_str()), popvcf::close_bgzf);
+
+  if (in_bgzf == nullptr)
+  {
+    std::cerr << "[popvcf] ERROR: Opening bgzf file " << fn << std::endl;
+    std::exit(1);
+  }
+
+  return in_bgzf;
+}
+
+inline void close_hts_file(htsFile * f)
+{
+  if (f != nullptr)
+  {
+    if (hts_close(f) != 0)
+    {
+      std::cerr << "[popvcf] ERROR: Failed closing hts file." << std::endl;
+      std::exit(1);
+    }
+  }
+}
+
+inline hts_file_ptr open_hts_file(const char * fn, const char * fm)
+{
+  hts_file_ptr ptr(hts_open(fn, fm), popvcf::close_hts_file);
+
+  if (ptr == nullptr)
+  {
+    std::cerr << "ERROR: Could not open file " << fn << std::endl;
+    std::exit(1);
+  }
+
+  return ptr;
+}
+
+inline void close_tbx_t(tbx_t * f)
+{
+  if (f != nullptr)
+    tbx_destroy(f);
+}
+
+inline tbx_t_ptr open_tbx_t(const char * fn)
+{
+  tbx_t_ptr ptr(tbx_index_load(fn), popvcf::close_tbx_t);
+
+  if (ptr == nullptr)
+  {
+    std::cerr << "[popvcf] ERROR: Could not open file " << fn << std::endl;
+    std::exit(1);
+  }
+
+  return ptr;
+}
+
+inline void close_hts_itr_t(hts_itr_t * f)
+{
+  if (f != nullptr)
+    tbx_itr_destroy(f);
+}
+
+inline hts_itr_t_ptr open_hts_itr_t(tbx_t * tbx, const char * region)
+{
+  hts_itr_t_ptr ptr(tbx_itr_querys(tbx, region), popvcf::close_hts_itr_t);
+
+  if (ptr == nullptr)
+    std::cerr << "[popvcf] WARNING: No records found in region " << region << "\n";
+
+  return ptr;
+}
+
+inline void free_kstring_t(kstring_t * str)
+{
+  if (str->s != NULL)
+    free(str->s);
 }
 } // namespace popvcf

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,12 @@ int subcmd_encode(paw::Parser & parser)
                                      "VCF",
                                      "Encode this VCF (or VCF.gz). If not set, read VCF from standard input.");
 
-    parser.parse_option(compression_threads, '@', "threads", "INT", "Output file compression level.");
+    parser.parse_option(compression_threads, '@', "threads", "Output file compression level.", "INT");
     parser.parse_option(input_type,
                         'I',
                         "input-type",
-                        "v|z|g",
-                        "Input type. v uncompressed VCF, z bgzipped VCF, g guess based on filename.");
+                        "Input type. v uncompressed VCF, z bgzipped VCF, g guess based on filename.",
+                        "v|z|g");
 
     parser.parse_option(no_previous_line,
                         ' ',
@@ -44,11 +44,10 @@ int subcmd_encode(paw::Parser & parser)
     parser.parse_option(output_compression_level,
                         'l',
                         "output-compress-level",
-                        "INT",
-                        "Output file compression level.");
+                        "Output file compression level.",
+                        "INT");
 
-    parser.parse_option(output_type, 'O', "output-type", "v|z", "Output type. v uncompressed VCF, z bgzipped VCF.");
-
+    parser.parse_option(output_type, 'O', "output-type", "Output type. v uncompressed VCF, z bgzipped VCF.", "v|z");
     parser.finalize();
   }
   catch (paw::exception::missing_positional_argument &)
@@ -85,9 +84,9 @@ int subcmd_decode(paw::Parser & parser)
     parser.parse_option(input_type,
                         'I',
                         "input-type",
-                        "v|z|g",
-                        "Input type. v uncompressed VCF, z bgzipped VCF, g guess based on filename.");
-    parser.parse_option(region, 'r', "region", "chrN:A-B", "Fetch region/interval to decode. Requires .tbi index.");
+                        "Input type. v uncompressed VCF, z bgzipped VCF, g guess based on filename.",
+                        "v|z|g");
+    parser.parse_option(region, 'r', "region", "Fetch region/interval to decode. Requires .tbi index.", "chrN:A-B");
     parser.parse_positional_argument(popvcf_fn, "popVCF", "Decode this popVCF. Use '-' for standard input.");
     parser.finalize();
   }


### PR DESCRIPTION
 * Wrapped I/O streams in std::unique_ptr
* Several code optimizations. Considerable benefit is seen in "popvcf decode".
 * Added a benchmark with tabix indexing.
 * Fixed clang-tidy warnings

Replaces PR #1 