### PR TITLE
Version 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,10 @@ endif()
 ###########
 
 enable_testing(true)
-add_test(NAME test_popvcf COMMAND sh -c "set -e; sh ${CMAKE_CURRENT_SOURCE_DIR}/test/create_test_data.sh > test.vcf ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf encode test.vcf -Oz > test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz > test.new.vcf ; diff test.vcf test.new.vcf ; tabix -p vcf test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz --region=chr2:10000-10200 | grep -v ^# | wc -l | grep -q -w -F 2")
+add_test(NAME test_popvcf COMMAND sh -c "set -e; sh ${CMAKE_CURRENT_SOURCE_DIR}/test/create_test_data.sh > test.vcf ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf encode test.vcf -Oz > test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz > test.new.vcf ; diff test.vcf test.new.vcf")
+
+# TODO add tabix to workflow or make popvcf build the index
+# tabix -p vcf test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz --region=chr2:10000-10200 | grep -v ^# | wc -l | grep -q -w -F 2
 
 set_tests_properties(test_popvcf PROPERTIES DEPENDS popvcf)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ set (STATIC_DIR "" CACHE STRING "Build in 'static' mode and include libraries in
 ## popvcf ##
 ############
 set (popvcf_VERSION_MAJOR 1)
-set (popvcf_VERSION_MINOR 0)
-set (popvcf_VERSION_PATCH 1)
+set (popvcf_VERSION_MINOR 1)
+set (popvcf_VERSION_PATCH 0)
 
 add_subdirectory(src) # Exposes "popvcf_sources", which contains all source files of popvcf
 add_library(popvcf_objects OBJECT ${popvcf_sources})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 ###########
 
 enable_testing(true)
-add_test(NAME test_popvcf COMMAND sh -c "set -e; sh ${CMAKE_CURRENT_SOURCE_DIR}/test/create_test_data.sh > test.vcf ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf encode test.vcf -Oz > test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz > test.new.vcf ; diff test.vcf test.new.vcf")
+add_test(NAME test_popvcf COMMAND sh -c "set -e; sh ${CMAKE_CURRENT_SOURCE_DIR}/test/create_test_data.sh > test.vcf ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf encode test.vcf -Oz > test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz > test.new.vcf ; diff test.vcf test.new.vcf ; tabix -p vcf test.popvcf.gz ; ${CMAKE_CURRENT_BINARY_DIR}/popvcf decode test.popvcf.gz --region=chr2:10000-10200 | grep -v ^# | wc -l | grep -q -w -F 2")
 
 set_tests_properties(test_popvcf PROPERTIES DEPENDS popvcf)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,45 @@
 ## popVCF
 
-popVCF losslessly encodes a multi sample VCF to reduce disk footprint. VCF fields are encoded by pointing to other exactly identical fields in the same row or in the row above. popVCF compression performance is small on a single sample VCF, but the compression ratio can go up to 40+ on a large population VCF or 5x more compressed than the standard bgzip compression.
+popVCF losslessly encodes a multi sample VCF to reduce disk footprint. VCF fields are encoded by pointing to other exactly identical fields in the same row or in the row above. popVCF compression performance is small on a single sample VCF, but the compression ratio can go up to 40+ on a large population VCFs or 5x more compressed than the standard bgzip compression. The compression ratio varies a lot between data sets, see below for benchmarks on several different data sets.
 
 Files are encoded with the "popvcf encode" command, and by encoding with the "-Oz" flag you can directly write the output in bgzip format. You can then decode the file back to VCF using the "popvcf decode" command. The decode subcommand can also query a region using option "--region=chrN:A-B".
 
 On a 64 bit linux, you can get the latest static binary from the [Release page](https://github.com/DecodeGenetics/popvcf/releases).
+
+### Benchmarks
+
+We have benchmarked popVCF against few other compression methods with some large population VCF data. In all experiements, we report wall clock time using /usr/bin/time and used a single CPU thread. The VCF data was read and written to a SSD disk. spVCF was run with the "--no-squeeze" option to prevent any lossy compression. The script run to benchmark is in the benchmark/ directory.  In the WGS benchmarks, we had to exclude genozip and VCFShark as they were unable to compress the data because of repeated runtime errors.
+
+Benchmarked versions: popVCF v1.1.0, spVCF v1.2.0-0-gbecb461, htslib+bcftools v1.14 (with libdeflate), Genozip 13.0.11, VCFShark v1.1.
+
+#### GraphTyper UK biobank WGS-487k individual data
+
+| Method/format | Compression ratio | Compared to bgzip |
+| ------------- | ----------------- | ----------------- |
+| popVCF+bgzip  |             37.6x |              4.4x |
+| spVCF+bgzip   |             17.2x |              2.0x |
+| BCF           |             10.5x |              1.2x |
+| bgzip (VCF)   |              8.6x |              1.0x |
+
+#### Deep Variant/GLnexus WES-200k individual data
+
+| Method/format | Compression ratio | Compared to bgzip | Compression speed (MB/s) | Decompression speed (MB/s) |
+| ------------- | ----------------- | ----------------- | ------------------------ | -------------------------- |
+| popVCF+bgzip  |            102.9x |              6.9x |                    194.0 |                      490.7 |
+| spVCF+bgzip   |             43.8x |              2.9x |                    129.7 |                      281.5 |
+| Genozip       |             35.0x |              2.3x |                     18.0 |                       17.3 |
+| VCFShark      |             28.3x |              1.9x |                     22.8 |                       21.7 |
+| BCF           |             14.0x |             0.94x |                     62.4 |                      175.2 |
+| bgzip (VCF)   |             14.9x |              1.0x |                     91.6 |                      521.3 |
+
+#### GATK UK biobank WGS-150k individual data
+
+| Method/format | Compression ratio | Compared to bgzip | Compression speed (MB/s) | Decompression speed (MB/s) |
+| ------------- | ----------------- | ----------------- | ------------------------ | -------------------------- |
+| popVCF+bgzip  |             20.1x |              2.8x |                    102.2 |                      295.0 |
+| spVCF+bgzip   |             10.0x |              1.4x |                     58.8 |                      165.7 |
+| BCF           |              6.7x |             0.94x |                     55.6 |                      174.2 |
+| bgzip (VCF)   |              7.1x |              1.0x |                     58.5 |                      474.7 |
 
 ### Usage
 

--- a/src/decode.cpp
+++ b/src/decode.cpp
@@ -169,7 +169,9 @@ void decode_region(std::string const & popvcf_fn, std::string const & region)
 
   while (ret > 0)
   {
-    if (get_vcf_pos(str.s, str.s + str.l) >= safe_begin)
+    long vcf_pos = get_vcf_pos(str.s, str.s + str.l);
+
+    if (vcf_pos >= safe_begin)
     {
       buffer_in.insert(buffer_in.end(), str.s, str.s + str.l);
       buffer_in.push_back('\n');
@@ -183,7 +185,7 @@ void decode_region(std::string const & popvcf_fn, std::string const & region)
       buffer_out.resize(0);
 
       /// Check if end position has been passed
-      if (not dd.in_region)
+      if (vcf_pos > dd.end)
         break;
     }
 

--- a/src/decode.cpp
+++ b/src/decode.cpp
@@ -126,13 +126,19 @@ void decode_region(std::string const & popvcf_fn, std::string const & region)
 
   /// Determine the region to query
   std::string safe_region = chrom;
+  long safe_begin;
 
   if (begin >= 0)
   {
+    safe_begin = std::max(1l, (begin / 10000l) * 10000l);
     safe_region.push_back(':');
-    safe_region.append(std::to_string(std::max(1l, (begin / 10000l) * 10000l)));
+    safe_region.append(std::to_string(std::max(1l, safe_begin)));
     safe_region.push_back('-');
     safe_region.append(std::to_string(end));
+  }
+  else
+  {
+    safe_begin = 0;
   }
 
   /// Input streams
@@ -163,20 +169,23 @@ void decode_region(std::string const & popvcf_fn, std::string const & region)
 
   while (ret > 0)
   {
-    buffer_in.insert(buffer_in.end(), str.s, str.s + str.l);
-    buffer_in.push_back('\n');
+    if (get_vcf_pos(str.s, str.s + str.l) >= safe_begin)
+    {
+      buffer_in.insert(buffer_in.end(), str.s, str.s + str.l);
+      buffer_in.push_back('\n');
 
-    decode_buffer</*in_region=*/true>(buffer_out, buffer_in, dd);
+      decode_buffer</*in_region=*/true>(buffer_out, buffer_in, dd);
 
-    /// Write buffer_out to stdout
-    fwrite(buffer_out.data(), 1, buffer_out.size(), stdout);
+      /// Write buffer_out to stdout
+      fwrite(buffer_out.data(), 1, buffer_out.size(), stdout);
 
-    /// Clears output buffer, but does not deallocate
-    buffer_out.resize(0);
+      /// Clears output buffer, but does not deallocate
+      buffer_out.resize(0);
 
-    /// Check if end position has been passed
-    if (dd.pos > dd.end)
-      break;
+      /// Check if end position has been passed
+      if (not dd.in_region)
+        break;
+    }
 
     /// Read more data
     ret = tbx_itr_next(in_bgzf.get(), in_tbx.get(), in_it.get(), &str);

--- a/src/decode.hpp
+++ b/src/decode.hpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <charconv>
 #include <cstdint>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <vector>
@@ -74,6 +75,7 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
 {
   set_input_size(buffer_in, dd);
   std::size_t constexpr N_FIELDS_SITE_DATA{9};
+  std::string next_contig{};
 
   // inner loop - Loops over each character in the input buffer
   while (dd.i < dd.in_size)
@@ -89,14 +91,28 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
     if (dd.field == 0)
     {
       dd.header_line = buffer_in[dd.b] == '#'; // check if in header line
+
+      if (not dd.header_line)
+      {
+        ++dd.i; // include '\t'
+        next_contig.assign(&buffer_in[dd.b], dd.i - dd.b);
+
+        /// Do not print this line until we know if we are inside the region or not
+        dd.b = dd.i;
+        ++dd.field;
+        continue;
+      }
     }
     else if (not dd.header_line)
     {
-      if (is_region && dd.field == 1) /*POS field */
+      if (dd.field == 1) /*POS field */
       {
-        uint32_t pos{};
+        long pos{};
         std::from_chars(&buffer_in[dd.b], &buffer_in[dd.i], pos); // get pos
-        dd.in_region = static_cast<int64_t>(pos) >= dd.begin && static_cast<int64_t>(pos) <= dd.end;
+        dd.in_region = pos >= dd.begin && pos <= dd.end;
+
+        if (!is_region || dd.in_region) /*print contig if we are inside the region*/
+          buffer_out.insert(buffer_out.end(), next_contig.begin(), next_contig.end());
       }
       else if (dd.field == 4) /* ALT field */
       {
@@ -115,11 +131,12 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
     }
     else
     {
-      long const field_idx = dd.field - N_FIELDS_SITE_DATA;
+      long field_idx = dd.field - N_FIELDS_SITE_DATA;
       assert(field_idx == static_cast<long>(dd.field2uid.size()));
 
-      if (buffer_in[dd.b] == '$' || buffer_in[dd.b] == '&')
+      while (buffer_in[dd.b] == '$' || buffer_in[dd.b] == '&')
       {
+        assert(dd.b < dd.i);
         assert(field_idx < static_cast<long>(dd.prev_field2uid.size()));
         assert(dd.prev_field2uid[field_idx] < static_cast<long>(dd.prev_unique_fields.size()));
 
@@ -135,18 +152,31 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
         else
         {
           /* Duplicate field in this line. Same as field above. */
+          assert(buffer_in[dd.b] == '&');
           auto find_it = dd.map_to_unique_fields.find(prior_field);
           assert(find_it != dd.map_to_unique_fields.end());
           dd.field2uid.push_back(find_it->second);
         }
 
-        ++dd.i;
+        ++dd.b;
+        ++dd.field;
+        ++field_idx;
 
         if (!is_region || dd.in_region)
         {
           buffer_out.insert(buffer_out.end(), prior_field.begin(), prior_field.end());
-          buffer_out.push_back(b_in);
+
+          if (dd.b < dd.i)
+            buffer_out.push_back('\t');
         }
+      }
+
+      if (buffer_in[dd.b] == '\n')
+      {
+        if (!is_region || dd.in_region)
+          buffer_out.push_back('\n');
+
+        ++dd.i;
       }
       else if (buffer_in[dd.b] == '%')
       {
@@ -197,7 +227,7 @@ inline void decode_buffer(Tbuffer_out & buffer_out, Tbuffer_in & buffer_in, Deco
           buffer_out.insert(buffer_out.end(), &buffer_in[dd.b], &buffer_in[dd.i]);
       }
 
-      assert((field_idx + 1) == static_cast<long>(dd.field2uid.size()));
+      // assert((field_idx + 1) == static_cast<long>(dd.field2uid.size()));
     }
 
     assert(b_in == buffer_in[dd.i - 1]);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -22,13 +22,11 @@ void encode_file(std::string const & input_fn,
                  std::string const & output_fn,
                  std::string const & output_mode,
                  bool const is_bgzf_output,
-                 int const compression_threads,
-                 bool const no_previous_line)
+                 int const compression_threads)
 {
   Tenc_array_buf buffer_in;     // input buffer
   std::vector<char> buffer_out; // output buffer
   EncodeData ed;                // encode data struct
-  ed.no_previous_line = no_previous_line;
 
   /// Open input file streams
   popvcf::bgzf_ptr in_bgzf(nullptr, popvcf::close_bgzf);   // bgzf input stream

--- a/src/sequence_utils.hpp
+++ b/src/sequence_utils.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cassert>
+#include <charconv>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -86,19 +88,36 @@ inline uint32_t ascii_cstring_to_int(char const * b, char const * e)
 template <typename Tint, typename Tbuffer_out>
 inline void to_chars(Tint char_val, Tbuffer_out & buffer_out)
 {
+  std::size_t constexpr ARR_SIZE{6};
+  std::array<char, ARR_SIZE> a;
+  std::size_t i{0};
+
   while (char_val >= CHAR_SET_SIZE)
   {
-    auto rem = char_val % CHAR_SET_SIZE;
+    Tint rem = char_val % CHAR_SET_SIZE;
     char_val = char_val / CHAR_SET_SIZE;
-    buffer_out.push_back(int_to_ascii(rem));
+    assert(i < ARR_SIZE);
+    a[i++] = int_to_ascii(rem);
   }
 
   assert(char_val < CHAR_SET_SIZE);
-  buffer_out.push_back(int_to_ascii(char_val));
+  assert(i < ARR_SIZE);
+  a[i++] = int_to_ascii(char_val);
+  buffer_out.insert(buffer_out.end(), a.data(), a.data() + i);
 }
 
 template <typename Tstring>
 std::vector<std::string_view> split_string(Tstring const & str, char const delimiter);
+
+template <typename Tit>
+long get_vcf_pos(Tit begin, Tit end)
+{
+  auto find_it1 = std::find(begin, end, '\t');
+  auto find_it2 = std::find(find_it1 + 1, end, '\t');
+  long vcf_pos{0};
+  std::from_chars(find_it1 + 1, find_it2, vcf_pos);
+  return vcf_pos;
+}
 
 template <typename Tbuffer_in>
 inline void resize_input_buffer(Tbuffer_in & buffer_in, std::size_t const new_size)

--- a/test/create_test_data.sh
+++ b/test/create_test_data.sh
@@ -3,6 +3,7 @@
 n=100000
 echo "##fileformat=VCFv4.2"
 echo "##contig=<ID=chr1>"
+echo "##contig=<ID=chr2>"
 echo "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype.\">"
 echo "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths.\">"
 echo "##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"PHRED-scaled genotype likelihoods.\">"
@@ -17,12 +18,12 @@ awk -v n=${n} 'BEGIN{
 awk -v n=${n} -v n_alts=3 'BEGIN{
   alt="AC"
   printf "\nchr1\t"n+2
-  printf "\t.\tA"
+  printf "\t.\tA\tA"
   for (a = 1; a <= n_alts; a++){
     alt=alt"C"
     printf ","alt
   }
-  printf "\t0\t.\t.\t.\tGT:AD:PL"
+  printf "\t0\t.\t.\tGT:AD:PL"
   for (i = 1; i <= n; i++){
     printf "\t0/0:"n_alts*10
     for (a = 1; a <= n_alts; a++){
@@ -40,12 +41,12 @@ awk -v n=${n} -v n_alts=3 'BEGIN{
 awk -v n=${n} -v n_alts=3 'BEGIN{
   alt="AC"
   printf "chr1\t"n+2
-  printf "\t.\tA"
+  printf "\t.\tA\tA"
   for (a = 1; a <= n_alts; a++){
     alt=alt"C"
     printf ","alt
   }
-  printf "\t0\t.\t.\t.\tGT:AD:PL"
+  printf "\t0\t.\t.\tGT:AD:PL"
   for (i = 1; i <= n; i++){
     printf "\t0/0:"n_alts*10
     for (a = 1; a <= n_alts; a++){
@@ -63,12 +64,12 @@ awk -v n=${n} -v n_alts=3 'BEGIN{
 awk -v n=${n} -v n_alts=3 'BEGIN{
   alt="AC"
   printf "chr1\t"n+2
-  printf "\t.\tA"
+  printf "\t.\tA\tA"
   for (a = 1; a <= n_alts; a++){
     alt=alt"C"
     printf ","alt
   }
-  printf "\t0\t.\t.\t.\tGT:AD:PL"
+  printf "\t0\t.\t.\tGT:AD:PL"
   for (i = 1; i <= n; i++){
     printf "\t0/0:"n_alts*10
     for (a = 1; a <= n_alts; a++){
@@ -87,12 +88,12 @@ awk -v n=${n} -v n_alts=3 'BEGIN{
 awk -v n=${n} -v n_alts=7 'BEGIN{
   alt="GT"
   printf "chr1\t"n+3
-  printf "\t.\tG"
+  printf "\t.\tG\tG"
   for (a = 1; a <= n_alts; a++){
     alt=alt"T"
     printf ","alt
   }
-  printf "\t0\t.\t.\t.\tGT:AD:PL"
+  printf "\t0\t.\t.\tGT:AD:PL"
   for (i = 1; i <= n; i++){
     printf "\t0/0:"n_alts*10
     for (a = 1; a <= n_alts; a++){
@@ -104,5 +105,33 @@ awk -v n=${n} -v n_alts=7 'BEGIN{
         printf ","a+i+b-2
       }
     }
+  }
+  printf "\n"}'
+
+awk -v n=${n} 'BEGIN{
+  printf "chr2\t9999\t.\tGTTTTTTT\tG\t0\t.\t.\tGT"
+  for (i = 1; i <= n; i++){
+    printf "\t0/0"
+  }
+  printf "\n"}'
+
+awk -v n=${n} 'BEGIN{
+  printf "chr2\t10000\t.\tGTTTTTTT\tG\t0\t.\t.\tGT"
+  for (i = 1; i <= n; i++){
+    printf "\t0/0"
+  }
+  printf "\n"}'
+
+awk -v n=${n} 'BEGIN{
+  printf "chr2\t10001\t.\tGTTTTTTT\tG\t0\t.\t.\tGT"
+  for (i = 1; i <= n; i++){
+    printf "\t0/0"
+  }
+  printf "\n"}'
+
+awk -v n=${n} 'BEGIN{
+  printf "chr2\t1000000\t.\tGTTTTTTT\tG\t0\t.\t.\tGT"
+  for (i = 1; i <= n; i++){
+    printf "\t0/0"
   }
   printf "\n"}'


### PR DESCRIPTION
 Release notes:
 * Adds benchmarks to README.
 * Adds a tar.gz that can be used for a bioconda package.
 * Several code optimizations to speed up both encoding and decoding.
 * Minor encoding changes include skipping writing TAB after '&' or '$' for a slightly better compression ratios. If you have some popVCF compressed files, please do not update or decode using popVCF v1.0 and re-encode using popVCF v1.1.